### PR TITLE
Provision bug fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "pinniped-cli",
-  "version": "0.4.6",
+  "version": "0.4.8",
   "description": "CLI tool for Creating, Managing, and Deploying your Pinniped projects",
   "main": "./src/index.js",
   "scripts": {

--- a/src/commands/provision.js
+++ b/src/commands/provision.js
@@ -79,9 +79,9 @@ const provision = async (agrv) => {
 
     await sshClient.connect(10);
 
+    await sshClient.runCommand("update");
     await sshClient.runCommand("installNode");
     await sshClient.runCommand("installPM2");
-    await sshClient.runCommand("update");
     await sshClient.runCommand("installLibcap2Bin");
     await sshClient.runCommand("setcap");
 

--- a/src/commands/start.js
+++ b/src/commands/start.js
@@ -13,7 +13,7 @@ const start = async () => {
       name: "proceed",
       message:
         "This command will start your deployed application using pm2 process manager\n" +
-        "  on your provisioned EC2 instance,\n\n" +
+        "  on your provisioned EC2 instance.\n\n" +
         "  Would you like to proceed?",
     },
   ]);

--- a/src/commands/start.js
+++ b/src/commands/start.js
@@ -13,8 +13,7 @@ const start = async () => {
       name: "proceed",
       message:
         "This command will start your deployed application using pm2 process manager\n" +
-        "  on your provisioned EC2 instance, and will allow you to enter a domain\n" +
-        "  for setting up HTTPS access to your application.\n\n" +
+        "  on your provisioned EC2 instance,\n\n" +
         "  Would you like to proceed?",
     },
   ]);

--- a/src/models/awsClient.js
+++ b/src/models/awsClient.js
@@ -28,7 +28,7 @@ export default class AWSClient {
         Values: ["available"],
       },
     ],
-    Owners: ["099720109477"], // Canonical's owner ID remains the same
+    Owners: ["099720109477"],
   };
   static IMAGE_PARAMS_X86_64 = {
     Filters: [
@@ -45,7 +45,7 @@ export default class AWSClient {
         Values: ["available"],
       },
     ],
-    Owners: ["099720109477"], // Canonical's owner ID remains the same
+    Owners: ["099720109477"],
   };
 
   /**
@@ -119,7 +119,6 @@ export default class AWSClient {
     this.amiId = instanceData.ImageId;
     this.instanceType = instanceData.InstanceType;
     this.keyName = instanceData.KeyName;
-    this.sandwhich = "blt";
   }
 
   /**
@@ -272,7 +271,7 @@ export default class AWSClient {
 
       if (sortedImages.length > 0) {
         this.spinner.text = `Image found: ${sortedImages[0].ImageId}`;
-        return sortedImages[0].ImageId; // Return the most recent AMI ID
+        return sortedImages[0].ImageId;
       } else {
         throw new Error("No suitable AMI found.");
       }
@@ -294,7 +293,6 @@ export default class AWSClient {
       KeyName: keyName,
       MaxCount: 1,
       MinCount: 1,
-      // SecurityGroups: [AWSClient.SECURITY_GROUP],
       SecurityGroupIds: [securityGroupID],
     };
 
@@ -311,11 +309,8 @@ export default class AWSClient {
 
       // Poll the EC2 instance state until it is "running"
       while (this.instanceState !== "running") {
+        await new Promise((resolve) => setTimeout(resolve, 2000));
         await this.syncEC2State();
-
-        if (this.instanceState !== "running") {
-          await new Promise((resolve) => setTimeout(resolve, 1000));
-        }
       }
 
       this.spinner.text = "Instance is now running";


### PR DESCRIPTION
### **Summary**
- Updates the `launchInstance` method in the `AWSClient` class to delay for 2 seconds **prior** to polling the state of the newly created instance using the `syncEC2status` method, rather than delaying after polling, provided that the EC2 instance state is not "running". 
  - I believe that in some cases the existence of the newly created EC2 instance was not populating throughout AWS quickly enough for an immediate `DescribeInstancesCommand` to be successfully run with the newly created instanceId, resulting in the error, "instance with id <instanceId> does not exist". 
- Updates the `pinniped provision` command to run a `sudo apt get update` command prior to attempting to install node and pm2. 
  - Occasionally, installing node and pm2 would fail on a newly provisioned EC2 instance. After making this change to run a  `sudo apt get update` command prior installing node and pm2, this bug has not resurfaced. 